### PR TITLE
Write output files to img directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ DAOD_PHYS*
 *.db
 *.val
 z*.yaml
+img/

--- a/notebooks/adl-benchmarks/direct-query.py
+++ b/notebooks/adl-benchmarks/direct-query.py
@@ -119,13 +119,15 @@ def ask(
 
             # Write out the png files
             if good_run and result is not None:
+                output_directory = output.parent / "img"
+                output_directory.mkdir(exist_ok=True)
                 for f_name, data in result.png_files:
                     # Sanitize model_name for filesystem
                     safe_model_name = model_name.replace("/", "_")
                     local_name = f"{question_hash}_{safe_model_name}_{f_name}"
-                    with open(local_name, "wb") as dst:
+                    with (output_directory / local_name).open("wb") as dst:
                         dst.write(data)
-                    fh_out.write(f"![{local_name}]({local_name})\n")
+                    fh_out.write(f"![{local_name}](img/{local_name})\n")
 
             # # If we are writing out the error info, we should do that here
             # if error_info and result is not None:

--- a/notebooks/adl-benchmarks/plan-query.py
+++ b/notebooks/adl-benchmarks/plan-query.py
@@ -357,15 +357,17 @@ plot_hist(r)
             if good_run:
                 fh_out.write("\n\n### Plots\n\n")
                 assert hist_result is not None
+                output_directory = output.parent / "img"
+                output_directory.mkdir(exist_ok=True)
                 for f_name, data in hist_result.png_files:
                     # Sanitize model_name for filesystem
                     safe_model_name = all_models[model_name].model_name.replace(
                         "/", "_"
                     )
-                    local_name = f"{question_hash}_{safe_model_name}_{f_name}"
-                    with open(local_name, "wb") as dst:
+                    local_name = f"{question_hash}_plan_{safe_model_name}_{f_name}"
+                    with (output_directory / local_name).open("wb") as dst:
                         dst.write(data)
-                    fh_out.write(f"![{local_name}]({local_name})")
+                    fh_out.write(f"![{local_name}](img/{local_name})")
 
         if model_usage:
             fh_out.write("\n\n## Model Usage\n\n")


### PR DESCRIPTION
- Create an `img` directory for storing output images.
- Update file writing logic to save PNG files in the new `img` directory.
- Adjust references in the output to point to the correct image paths.

Fixes #46